### PR TITLE
Fixed: Incorrect method used for closing session.

### DIFF
--- a/logout.php
+++ b/logout.php
@@ -2,7 +2,7 @@
     include("core.php");
     start_session();
     validate_session();
-    ses_close();
+    close_session();
 
 
     header("Location: ".get_main_path());


### PR DESCRIPTION
This fixes an incorrect method used upon logout to close session causing a PHP error upon logout.
`src/session-manager.php` defines `close_session()` instead of `ses_close()`.